### PR TITLE
Fix missing assignment for projected graph

### DIFF
--- a/create_method_similarity.py
+++ b/create_method_similarity.py
@@ -61,14 +61,18 @@ def run_knn(gds, top_k=5, cutoff=0.8):
     try:
         gds.knn.write(**base_config)
     except Exception as e:
-        # Older GDS versions expect a graph name as the first argument.
-        if "Type mismatch" not in str(e):
+        # Older GDS versions expect a graph name as the first argument, which
+        # results in a TypeError complaining about a missing "G" parameter.
+        if (
+            "Type mismatch" not in str(e)
+            and "missing 1 required positional argument" not in str(e)
+        ):
             raise
 
-        gds.graph.project("methodGraph", "Method", {})
+        graph, _ = gds.graph.project("methodGraph", "Method", {})
         config = {k: base_config[k] for k in base_config if k != "nodeProjection"}
-        gds.knn.write("methodGraph", **config)
-        gds.graph.drop("methodGraph")
+        gds.knn.write(graph, **config)
+        graph.drop()
 
 
 def main():


### PR DESCRIPTION
## Summary
- project the `Method` graph into a variable when falling back to old GDS API

## Testing
- `python -m py_compile create_method_similarity.py`


------
https://chatgpt.com/codex/tasks/task_e_68782d188b6483328e6df94db64ef7a4