### PR TITLE
Move ensure_port to utils

### DIFF
--- a/code_to_graph.py
+++ b/code_to_graph.py
@@ -11,31 +11,11 @@ from transformers import AutoTokenizer, AutoModel
 import torch
 import javalang
 from dotenv import load_dotenv
-from urllib.parse import urlparse, urlunparse
+from utils import ensure_port
 
 # Load environment variables from a .env file and override any existing
 # variables so that local configuration takes precedence.
 load_dotenv(override=True)
-
-
-def ensure_port(uri, default=7687):
-    """Return URI with default port if none specified."""
-    parsed = urlparse(uri)
-    # When no netloc is present urlparse puts the host into the path
-    host = parsed.hostname or parsed.path
-    port = parsed.port
-    if port is None:
-        # Reconstruct URI with default port and existing auth info
-        auth = ""
-        if parsed.username:
-            auth = parsed.username
-            if parsed.password:
-                auth += f":{parsed.password}"
-            auth += "@"
-        netloc = f"{auth}{host}:{default}"
-        parsed = parsed._replace(netloc=netloc, path="")
-        uri = urlunparse(parsed)
-    return uri
 
 # Apply a default port if one is missing from the URI
 NEO4J_URI = ensure_port(os.environ.get("NEO4J_URI", "bolt://localhost:7687"))

--- a/create_method_similarity.py
+++ b/create_method_similarity.py
@@ -1,28 +1,12 @@
 import os
-from urllib.parse import urlparse, urlunparse
 from dotenv import load_dotenv
 from graphdatascience import GraphDataScience
 import argparse
 
+from utils import ensure_port
+
 # Load env vars
 load_dotenv(override=True)
-
-
-def ensure_port(uri, default=7687):
-    parsed = urlparse(uri)
-    host = parsed.hostname or parsed.path
-    port = parsed.port
-    if port is None:
-        auth = ""
-        if parsed.username:
-            auth = parsed.username
-            if parsed.password:
-                auth += f":{parsed.password}"
-            auth += "@"
-        netloc = f"{auth}{host}:{default}"
-        parsed = parsed._replace(netloc=netloc, path="")
-        uri = urlunparse(parsed)
-    return uri
 
 
 NEO4J_URI = ensure_port(os.getenv("NEO4J_URI", "bolt://localhost:7687"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from utils import ensure_port
+
+
+def test_adds_default_port():
+    assert ensure_port("bolt://localhost") == "bolt://localhost:7687"
+
+
+def test_keeps_existing_port():
+    assert ensure_port("bolt://localhost:9999") == "bolt://localhost:9999"
+
+
+def test_handles_auth():
+    assert ensure_port("bolt://user:pass@localhost") == "bolt://user:pass@localhost:7687"

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,20 @@
+from urllib.parse import urlparse, urlunparse
+
+
+def ensure_port(uri: str, default: int = 7687) -> str:
+    """Return the URI with a port, using ``default`` if none present."""
+    parsed = urlparse(uri)
+    # When the URI lacks a netloc, ``urlparse`` places the host in ``path``
+    host = parsed.hostname or parsed.path
+    port = parsed.port
+    if port is None:
+        auth = ""
+        if parsed.username:
+            auth = parsed.username
+            if parsed.password:
+                auth += f":{parsed.password}"
+            auth += "@"
+        netloc = f"{auth}{host}:{default}"
+        parsed = parsed._replace(netloc=netloc, path="")
+        uri = urlunparse(parsed)
+    return uri


### PR DESCRIPTION
## Summary
- extract `ensure_port` into new `utils.py`
- reuse `ensure_port` from `utils` in `code_to_graph.py` and `create_method_similarity.py`
- add basic tests for `ensure_port`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796b7934748332955318b62eba1105