### PR TITLE
Add unit tests for queries and GDS flow

### DIFF
--- a/tests/test_code_to_graph.py
+++ b/tests/test_code_to_graph.py
@@ -1,0 +1,43 @@
+import sys
+import types
+from unittest import mock
+from pathlib import Path
+import tempfile
+
+# Provide stub modules for heavy dependencies before importing the module under test
+sys.modules['transformers'] = types.ModuleType('transformers')
+sys.modules['transformers'].AutoTokenizer = object
+sys.modules['transformers'].AutoModel = object
+
+sys.modules['neo4j'] = types.ModuleType('neo4j')
+sys.modules['neo4j'].GraphDatabase = mock.MagicMock()
+sys.modules['dotenv'] = types.ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda override=True: None
+
+sys.modules['torch'] = types.ModuleType('torch')
+class _NoGrad:
+    def __enter__(self):
+        pass
+    def __exit__(self, exc_type, exc, tb):
+        pass
+sys.modules['torch'].no_grad = lambda: _NoGrad()
+
+import code_to_graph
+
+
+def test_process_java_file_runs_expected_queries():
+    java_code = """public class Test {\n    public void foo() {}\n}\n"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "Test.java"
+        file_path.write_text(java_code)
+
+        session = mock.MagicMock()
+        with mock.patch.object(code_to_graph, 'compute_embedding', return_value=[0]*code_to_graph.EMBEDDING_DIM):
+            code_to_graph.process_java_file(file_path, None, None, session, Path(tmpdir))
+
+        # Expect two Cypher queries: one for File node and one for Method node
+        assert session.run.call_count == 2
+        file_query = session.run.call_args_list[0].args[0]
+        method_query = session.run.call_args_list[1].args[0]
+        assert "MERGE (f:File" in file_query
+        assert "MERGE (m:Method" in method_query

--- a/tests/test_create_method_similarity.py
+++ b/tests/test_create_method_similarity.py
@@ -1,0 +1,47 @@
+import sys
+import types
+from unittest import mock
+
+# Stub graphdatascience before importing
+sys.modules['graphdatascience'] = types.ModuleType('graphdatascience')
+sys.modules['graphdatascience'].GraphDataScience = object
+sys.modules['dotenv'] = types.ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda override=True: None
+
+import create_method_similarity as cms
+
+
+def make_gds(modern=True):
+    gds = mock.MagicMock()
+    gds.graph = mock.MagicMock()
+    graph_obj = mock.MagicMock()
+    gds.graph.project.return_value = (graph_obj, None)
+    if modern:
+        gds.knn.write.return_value = None
+    else:
+        gds.knn.write.side_effect = [TypeError("missing 1 required positional argument"), None]
+    return gds, graph_obj
+
+
+def test_run_knn_modern_api():
+    gds, _ = make_gds(modern=True)
+    cms.run_knn(gds, top_k=3, cutoff=0.5)
+    gds.knn.write.assert_called_once()
+    args, kwargs = gds.knn.write.call_args
+    assert kwargs['topK'] == 3
+    assert kwargs['similarityCutoff'] == 0.5
+    assert kwargs['writeRelationshipType'] == 'SIMILAR'
+    assert not gds.graph.project.called
+
+
+def test_run_knn_legacy_api():
+    gds, graph_obj = make_gds(modern=False)
+    cms.run_knn(gds, top_k=2, cutoff=0.1)
+    assert gds.knn.write.call_count == 2
+    gds.graph.drop.assert_called_with('methodGraph')
+    gds.graph.project.assert_called_with(
+        'methodGraph',
+        {'Method': {'properties': 'embedding'}},
+        '*'
+    )
+    graph_obj.drop.assert_called_once()


### PR DESCRIPTION
## Summary
- add tests for expected Cypher calls in `process_java_file`
- add tests for `run_knn` covering modern and legacy GDS APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796b842e9c8332a719c486cfdba3e8