### PR TITLE
Fix flake8 long lines

### DIFF
--- a/create_method_similarity.py
+++ b/create_method_similarity.py
@@ -22,12 +22,20 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Create SIMILAR relationships between methods"
     )
-    parser.add_argument("--uri", default=NEO4J_URI, help="Neo4j connection URI")
     parser.add_argument(
-        "--username", default=NEO4J_USERNAME, help="Neo4j authentication username"
+        "--uri",
+        default=NEO4J_URI,
+        help="Neo4j connection URI",
     )
     parser.add_argument(
-        "--password", default=NEO4J_PASSWORD, help="Neo4j authentication password"
+        "--username",
+        default=NEO4J_USERNAME,
+        help="Neo4j authentication username",
+    )
+    parser.add_argument(
+        "--password",
+        default=NEO4J_PASSWORD,
+        help="Neo4j authentication password",
     )
     parser.add_argument(
         "--database",
@@ -72,8 +80,9 @@ def run_knn(gds, top_k=5, cutoff=0.8):
     try:
         gds.knn.write(**base_config)
     except Exception as e:
-        # Older GDS versions expect a graph name as the first argument, which
-        # results in a TypeError complaining about a missing "G" parameter.
+        # Older GDS versions expect a graph name as the first argument,
+        # which results in a TypeError complaining about a missing "G"
+        # parameter.
         if (
             "Type mismatch" not in str(e)
             and "missing 1 required positional argument" not in str(e)
@@ -83,16 +92,20 @@ def run_knn(gds, top_k=5, cutoff=0.8):
         # Drop any existing graph with the same name
         try:
             gds.graph.drop("methodGraph")
-        except:
+        except Exception:
             pass  # Graph doesn't exist, which is fine
-        
+
         # Create graph projection with node properties included
         graph, _ = gds.graph.project(
-            "methodGraph", 
-            {"Method": {"properties": "embedding"}}, 
-            "*"
+            "methodGraph",
+            {"Method": {"properties": "embedding"}},
+            "*",
         )
-        config = {k: base_config[k] for k in base_config if k != "nodeProjection"}
+        config = {
+            k: base_config[k]
+            for k in base_config
+            if k != "nodeProjection"
+        }
         gds.knn.write(graph, **config)
         graph.drop()
 

--- a/tests/test_code_to_graph.py
+++ b/tests/test_code_to_graph.py
@@ -20,7 +20,10 @@ class _NoGrad:
     def __exit__(self, *exc):
         pass
 
-sys.modules.setdefault("torch", types.SimpleNamespace(no_grad=lambda: _NoGrad()))
+sys.modules.setdefault(
+    "torch",
+    types.SimpleNamespace(no_grad=lambda: _NoGrad()),
+)
 
 
 import code_to_graph
@@ -42,11 +45,22 @@ def test_load_repo_executes_cypher(tmp_path):
     driver_mock = MagicMock()
     driver_mock.session.return_value = session_cm
 
-    with patch.object(code_to_graph.GraphDatabase, "driver", return_value=driver_mock) as mock_driver, \
-         patch.object(code_to_graph.Repo, "clone_from", side_effect=fake_clone_from), \
-         patch.object(code_to_graph, "AutoTokenizer"), \
-         patch.object(code_to_graph, "AutoModel"), \
-         patch.object(code_to_graph, "compute_embedding", return_value=[0.0]):
+    with patch.object(
+        code_to_graph.GraphDatabase,
+        "driver",
+        return_value=driver_mock,
+    ) as mock_driver, patch.object(
+        code_to_graph.Repo,
+        "clone_from",
+        side_effect=fake_clone_from,
+    ), patch.object(code_to_graph, "AutoTokenizer"), patch.object(
+        code_to_graph,
+        "AutoModel",
+    ), patch.object(
+        code_to_graph,
+        "compute_embedding",
+        return_value=[0.0],
+    ):
         driver = code_to_graph.GraphDatabase.driver("bolt://localhost:7687")
         code_to_graph.load_repo("dummy_url", driver)
         mock_driver.assert_called_once()
@@ -71,7 +85,11 @@ def test_process_java_file_creates_directories(tmp_path):
         )
 
     calls = session_mock.run.call_args_list
-    dir_paths = [c.kwargs["path"] for c in calls if c.args[0].startswith("MERGE (:Directory")]
+    dir_paths = [
+        c.kwargs["path"]
+        for c in calls
+        if c.args[0].startswith("MERGE (:Directory")
+    ]
     assert dir_paths == ["a", "a/b"]
 
     assert any(

--- a/tests/test_create_method_similarity.py
+++ b/tests/test_create_method_similarity.py
@@ -19,7 +19,10 @@ def make_gds(modern=True):
     if modern:
         gds.knn.write.return_value = None
     else:
-        gds.knn.write.side_effect = [TypeError("missing 1 required positional argument"), None]
+        gds.knn.write.side_effect = [
+            TypeError("missing 1 required positional argument"),
+            None,
+        ]
     return gds, graph_obj
 
 

--- a/tests/test_ensure_port.py
+++ b/tests/test_ensure_port.py
@@ -20,7 +20,10 @@ def _stub_module(name, attrs=None):
 HEAVY_MODULES = {
     "git": _stub_module("git", ["Repo"]),
     "neo4j": _stub_module("neo4j", ["GraphDatabase"]),
-    "transformers": _stub_module("transformers", ["AutoTokenizer", "AutoModel"]),
+    "transformers": _stub_module(
+        "transformers",
+        ["AutoTokenizer", "AutoModel"],
+    ),
     "torch": _stub_module("torch"),
     "javalang": _stub_module("javalang"),
     "dotenv": _stub_module("dotenv", ["load_dotenv"]),
@@ -28,7 +31,10 @@ HEAVY_MODULES = {
 }
 
 
-@pytest.mark.parametrize("module_name", ["code_to_graph", "create_method_similarity"])
+@pytest.mark.parametrize(
+    "module_name",
+    ["code_to_graph", "create_method_similarity"],
+)
 @pytest.mark.parametrize(
     "uri, expected",
     [
@@ -42,4 +48,3 @@ def test_ensure_port(module_name, uri, expected):
     with patch.dict(sys.modules, HEAVY_MODULES):
         module = importlib.import_module(module_name)
         assert module.ensure_port(uri) == expected
-

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -27,7 +27,10 @@ def test_run_knn_legacy_api():
     gds = MagicMock()
     graph_mock = MagicMock()
     gds.graph.project.return_value = (graph_mock, None)
-    gds.knn.write.side_effect = [TypeError("missing 1 required positional argument"), None]
+    gds.knn.write.side_effect = [
+        TypeError("missing 1 required positional argument"),
+        None,
+    ]
 
     run_knn(gds, top_k=4, cutoff=0.7)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,4 +15,6 @@ def test_keeps_existing_port():
 
 
 def test_handles_auth():
-    assert ensure_port("bolt://user:pass@localhost") == "bolt://user:pass@localhost:7687"
+    assert ensure_port("bolt://user:pass@localhost") == (
+        "bolt://user:pass@localhost:7687"
+    )


### PR DESCRIPTION
## Summary
- format CLI option handling in create_method_similarity
- reformat code_to_graph for long lines
- wrap lines in tests to comply with flake8
- handle bare `except:` in create_method_similarity

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879cffdc2f88332bc068fbcee879c2b