### PR TITLE
Introduce shared Neo4j config helper

### DIFF
--- a/code_to_graph.py
+++ b/code_to_graph.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import tempfile
 import shutil
@@ -10,18 +9,10 @@ from neo4j import GraphDatabase
 from transformers import AutoTokenizer, AutoModel
 import torch
 import javalang
-from dotenv import load_dotenv
-from utils import ensure_port
+from utils import ensure_port, get_neo4j_config
 
-# Load environment variables from a .env file and override any existing
-# variables so that local configuration takes precedence.
-load_dotenv(override=True)
-
-# Apply a default port if one is missing from the URI
-NEO4J_URI = ensure_port(os.environ.get("NEO4J_URI", "bolt://localhost:7687"))
-NEO4J_USERNAME = os.environ.get("NEO4J_USERNAME", "neo4j")
-NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", "neo4j")
-NEO4J_DATABASE = os.environ.get("NEO4J_DATABASE", "neo4j")
+# Read connection settings from the environment
+NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE = get_neo4j_config()
 
 # ---------------------------------------------------------------------------
 # Argument parsing

--- a/create_method_similarity.py
+++ b/create_method_similarity.py
@@ -1,18 +1,10 @@
-import os
-from dotenv import load_dotenv
-from graphdatascience import GraphDataScience
 import argparse
+from graphdatascience import GraphDataScience
 
-from utils import ensure_port
+from utils import ensure_port, get_neo4j_config
 
-# Load env vars
-load_dotenv(override=True)
-
-
-NEO4J_URI = ensure_port(os.getenv("NEO4J_URI", "bolt://localhost:7687"))
-NEO4J_USERNAME = os.getenv("NEO4J_USERNAME", "neo4j")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "neo4j")
-NEO4J_DATABASE = os.getenv("NEO4J_DATABASE", "neo4j")
+# Connection settings
+NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE = get_neo4j_config()
 
 EMBEDDING_DIM = 768
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from utils import ensure_port
+from utils import ensure_port, get_neo4j_config
 
 
 def test_adds_default_port():
@@ -18,3 +18,17 @@ def test_handles_auth():
     assert ensure_port("bolt://user:pass@localhost") == (
         "bolt://user:pass@localhost:7687"
     )
+
+
+def test_get_neo4j_config_reads_env(monkeypatch):
+    monkeypatch.setenv("NEO4J_URI", "bolt://example")
+    monkeypatch.setenv("NEO4J_USERNAME", "u")
+    monkeypatch.setenv("NEO4J_PASSWORD", "p")
+    monkeypatch.setenv("NEO4J_DATABASE", "d")
+
+    uri, user, pw, db = get_neo4j_config()
+
+    assert uri == "bolt://example:7687"
+    assert user == "u"
+    assert pw == "p"
+    assert db == "d"

--- a/utils.py
+++ b/utils.py
@@ -18,3 +18,16 @@ def ensure_port(uri: str, default: int = 7687) -> str:
         parsed = parsed._replace(netloc=netloc, path="")
         uri = urlunparse(parsed)
     return uri
+
+
+def get_neo4j_config():
+    """Return connection settings after loading environment variables."""
+    from dotenv import load_dotenv
+    import os
+
+    load_dotenv(override=True)
+    uri = ensure_port(os.getenv("NEO4J_URI", "bolt://localhost:7687"))
+    username = os.getenv("NEO4J_USERNAME", "neo4j")
+    password = os.getenv("NEO4J_PASSWORD", "neo4j")
+    database = os.getenv("NEO4J_DATABASE", "neo4j")
+    return uri, username, password, database


### PR DESCRIPTION
## Summary
- add `get_neo4j_config` utility for loading connection settings
- refactor `code_to_graph.py` and `create_method_similarity.py` to reuse the helper
- extend unit tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d8e26e888332a5c100b9b4230396