### PR TITLE
Use CLI parsing in main

### DIFF
--- a/code_to_graph.py
+++ b/code_to_graph.py
@@ -250,13 +250,10 @@ def load_repo(repo_url, driver, database=None):
 
 
 def main():
-    if len(sys.argv) != 2:
-        print("Usage: python code_to_graph.py <git_repo_url>")
-        sys.exit(1)
-    repo_url = sys.argv[1]
+    args = parse_args()
     try:
         driver = GraphDatabase.driver(
-            NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD)
+            ensure_port(args.uri), auth=(args.username, args.password)
         )
         # Fail fast if the Neo4j connection details are incorrect
         driver.verify_connectivity()
@@ -265,7 +262,7 @@ def main():
         sys.exit(1)
 
     try:
-        load_repo(repo_url, driver, NEO4J_DATABASE)
+        load_repo(args.repo_url, driver, args.database)
     finally:
         driver.close()
 


### PR DESCRIPTION
## Summary
- simplify `main()` by using `parse_args()`
- ensure the driver URI always has a port
- pass user supplied options through to `load_repo`
- test that `main()` honours optional arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879dee9c8048332bbb4c61de7782b62