### PR TITLE
Add unit test for create_index

### DIFF
--- a/tests/test_create_method_similarity.py
+++ b/tests/test_create_method_similarity.py
@@ -48,3 +48,19 @@ def test_run_knn_legacy_api():
         '*'
     )
     graph_obj.drop.assert_called_once()
+
+
+def test_create_index_executes_cypher():
+    gds = mock.MagicMock()
+
+    cms.create_index(gds)
+
+    calls = gds.run_cypher.call_args_list
+    assert len(calls) == 2
+
+    first_call = calls[0]
+    assert "CREATE VECTOR INDEX method_embeddings" in first_call.args[0]
+    assert first_call.kwargs["params"] == {"dim": cms.EMBEDDING_DIM}
+
+    second_call = calls[1]
+    assert second_call.args[0] == "CALL db.awaitIndex('method_embeddings')"


### PR DESCRIPTION
## Summary
- ensure create_index executes expected Cypher commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879df159d288332ac1ab4d32f72777a