### PR TITLE
Improve logging and add style checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # AGENTS Instructions
 
-- Install dependencies from `requirements.txt`.
-- Run `pytest -q` before committing.
-- Optional: Format Python code with `black`.
+- Install dependencies from `requirements.txt` and `dev-requirements.txt`.
+- Run `flake8` and `pytest -q` before committing.
+- Format Python code with `black`.
+- `.env` contains Neo4j connection settings used by tests.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ python code_to_graph.py <repo_url> \
   --uri bolt://localhost:7687 \
   --username neo4j \
   --password secret \
-  --database neo4j
+  --database neo4j \
+  --log-level INFO
 ```
 
 Where:
@@ -77,6 +78,8 @@ creates `File` nodes for each source file and `Method` nodes for each
 method. Method invocations are linked with `CALLS` relationships, and
 each node stores an embedding vector for similarity search. Similarity
 relationships are created separately using `create_method_similarity.py`.
+Logging output can be controlled with the `--log-level` option, and a
+progress bar is displayed while processing files.
 
 ### Build similarity relationships
 
@@ -136,9 +139,10 @@ RETURN called.name LIMIT 10;
 
 ## Testing
 
-Run the test suite with `pytest`:
+Run the style checks and test suite:
 
 ```bash
+flake8
 pytest -q
 ```
 

--- a/create_method_similarity.py
+++ b/create_method_similarity.py
@@ -1,4 +1,6 @@
 import argparse
+import logging
+from time import perf_counter
 from graphdatascience import GraphDataScience
 
 from utils import ensure_port, get_neo4j_config
@@ -7,6 +9,9 @@ from utils import ensure_port, get_neo4j_config
 NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE = get_neo4j_config()
 
 EMBEDDING_DIM = 768
+
+
+logger = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -37,13 +42,17 @@ def parse_args():
     parser.add_argument(
         "--top-k", type=int, default=5, help="Number of nearest neighbours"
     )
+    parser.add_argument("--cutoff", type=float, default=0.8, help="Similarity cutoff")
     parser.add_argument(
-        "--cutoff", type=float, default=0.8, help="Similarity cutoff"
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR)",
     )
     return parser.parse_args()
 
 
 def create_index(gds):
+    logger.info("Ensuring vector index exists")
     gds.run_cypher(
         """
         CREATE VECTOR INDEX method_embeddings IF NOT EXISTS
@@ -70,17 +79,24 @@ def run_knn(gds, top_k=5, cutoff=0.8):
     }
 
     try:
+        start = perf_counter()
         gds.knn.write(**base_config)
+        logger.info(
+            "kNN wrote relationships for top %d with cutoff %.2f in %.2fs",
+            top_k,
+            cutoff,
+            perf_counter() - start,
+        )
     except Exception as e:
         # Older GDS versions expect a graph name as the first argument,
         # which results in a TypeError complaining about a missing "G"
         # parameter.
-        if (
-            "Type mismatch" not in str(e)
-            and "missing 1 required positional argument" not in str(e)
-        ):
+        if "Type mismatch" not in str(
+            e
+        ) and "missing 1 required positional argument" not in str(e):
             raise
 
+        logger.debug("Falling back to legacy GDS API")
         # Drop any existing graph with the same name
         try:
             gds.graph.drop("methodGraph")
@@ -93,17 +109,21 @@ def run_knn(gds, top_k=5, cutoff=0.8):
             {"Method": {"properties": "embedding"}},
             "*",
         )
-        config = {
-            k: base_config[k]
-            for k in base_config
-            if k != "nodeProjection"
-        }
+        config = {k: base_config[k] for k in base_config if k != "nodeProjection"}
+        start = perf_counter()
         gds.knn.write(graph, **config)
         graph.drop()
+        logger.info(
+            "kNN (legacy) wrote relationships for top %d with cutoff %.2f in %.2fs",
+            top_k,
+            cutoff,
+            perf_counter() - start,
+        )
 
 
 def main():
     args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), "INFO"))
 
     gds = GraphDataScience(
         ensure_port(args.uri),
@@ -112,10 +132,11 @@ def main():
         arrow=False,
     )
     gds.run_cypher("RETURN 1")  # verify connectivity
+    logger.info("Connected to Neo4j at %s", ensure_port(args.uri))
     create_index(gds)
     run_knn(gds, args.top_k, args.cutoff)
     gds.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ javalang==0.13.0
 neo4j==5.28.1
 graphdatascience==1.16
 python-dotenv==1.1.1
+tqdm==4.66.4

--- a/tests/test_code_to_graph.py
+++ b/tests/test_code_to_graph.py
@@ -13,6 +13,7 @@ sys.modules.setdefault(
     types.SimpleNamespace(AutoTokenizer=MagicMock(), AutoModel=MagicMock()),
 )
 
+
 class _NoGrad:
     def __enter__(self):
         pass
@@ -20,16 +21,14 @@ class _NoGrad:
     def __exit__(self, *exc):
         pass
 
+
 sys.modules.setdefault(
     "torch",
     types.SimpleNamespace(no_grad=lambda: _NoGrad()),
 )
 
 sys.modules.setdefault("git", types.SimpleNamespace(Repo=MagicMock()))
-sys.modules.setdefault(
-    "neo4j",
-    types.SimpleNamespace(GraphDatabase=MagicMock())
-)
+sys.modules.setdefault("neo4j", types.SimpleNamespace(GraphDatabase=MagicMock()))
 sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda **k: None))
 
 
@@ -60,7 +59,9 @@ def test_load_repo_executes_cypher(tmp_path):
         code_to_graph.Repo,
         "clone_from",
         side_effect=fake_clone_from,
-    ), patch.object(code_to_graph, "AutoTokenizer"), patch.object(
+    ), patch.object(
+        code_to_graph, "AutoTokenizer"
+    ), patch.object(
         code_to_graph,
         "AutoModel",
     ), patch.object(
@@ -93,9 +94,7 @@ def test_process_java_file_creates_directories(tmp_path):
 
     calls = session_mock.run.call_args_list
     dir_paths = [
-        c.kwargs["path"]
-        for c in calls
-        if c.args[0].startswith("MERGE (:Directory")
+        c.kwargs["path"] for c in calls if c.args[0].startswith("MERGE (:Directory")
     ]
     assert dir_paths == ["a", "a/b"]
 
@@ -120,9 +119,7 @@ def test_process_java_file_creates_directories(tmp_path):
 
 def test_process_java_file_creates_calls(tmp_path):
     java_file = tmp_path / "Foo.java"
-    java_file.write_text(
-        "class Foo { void bar() { baz(); } void baz() {} }"
-    )
+    java_file.write_text("class Foo { void bar() { baz(); } void baz() {} }")
 
     session_mock = MagicMock()
 
@@ -145,13 +142,16 @@ def test_main_accepts_optional_arguments(monkeypatch):
         username="neo4j",
         password="secret",
         database="testdb",
+        log_level="INFO",
     )
 
     driver_instance = MagicMock()
     monkeypatch.setattr(code_to_graph, "parse_args", lambda: args)
     ensure_port_mock = MagicMock(return_value="bolt://example:9999")
     monkeypatch.setattr(code_to_graph, "ensure_port", ensure_port_mock)
-    monkeypatch.setattr(code_to_graph.GraphDatabase, "driver", MagicMock(return_value=driver_instance))
+    monkeypatch.setattr(
+        code_to_graph.GraphDatabase, "driver", MagicMock(return_value=driver_instance)
+    )
     load_repo_mock = MagicMock()
     monkeypatch.setattr(code_to_graph, "load_repo", load_repo_mock)
 
@@ -162,6 +162,8 @@ def test_main_accepts_optional_arguments(monkeypatch):
         "bolt://example:9999",
         auth=(args.username, args.password),
     )
-    load_repo_mock.assert_called_once_with(args.repo_url, driver_instance, args.database)
+    load_repo_mock.assert_called_once_with(
+        args.repo_url, driver_instance, args.database
+    )
     driver_instance.verify_connectivity.assert_called_once()
     driver_instance.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add tqdm and logging to track progress when processing repositories
- expose log-level option on both scripts
- record timing metrics and log progress
- document `--log-level`, update testing instructions, add flake8 to AGENTS
- keep tests passing with new arguments

## Testing
- `pytest -q`
- `flake8 | head`

------
https://chatgpt.com/codex/tasks/task_e_687a35513bbc833283e3e8f666412fe2