### PR TITLE
Improve logging options

### DIFF
--- a/create_method_similarity.py
+++ b/create_method_similarity.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import sys
 from time import perf_counter
 from graphdatascience import GraphDataScience
 
@@ -47,6 +48,10 @@ def parse_args():
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING, ERROR)",
+    )
+    parser.add_argument(
+        "--log-file",
+        help="Write logs to this file as well as the console",
     )
     return parser.parse_args()
 
@@ -123,7 +128,14 @@ def run_knn(gds, top_k=5, cutoff=0.8):
 
 def main():
     args = parse_args()
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), "INFO"))
+    handlers = [logging.StreamHandler(sys.stdout)]
+    if args.log_file:
+        handlers.append(logging.FileHandler(args.log_file))
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), "INFO"),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+    )
 
     gds = GraphDataScience(
         ensure_port(args.uri),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,E402

--- a/tests/test_code_to_graph.py
+++ b/tests/test_code_to_graph.py
@@ -143,6 +143,7 @@ def test_main_accepts_optional_arguments(monkeypatch):
         password="secret",
         database="testdb",
         log_level="INFO",
+        log_file=None,
     )
 
     driver_instance = MagicMock()


### PR DESCRIPTION
## Summary
- add `--log-file` option for console and file logging
- include timestamps and log level in log formatting
- configure flake8 defaults
- update test for new argument

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5575ee9483328b85ab226ab54508