### PR TITLE
Clarify database setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,4 +3,6 @@
 - Install dependencies from `requirements.txt` and `dev-requirements.txt`.
 - Run `flake8` and `pytest -q` before committing.
 - Format Python code with `black`.
-- `.env` contains Neo4j connection settings used by tests.
+- Tests mock the database connection, so they pass without a running Neo4j
+  instance. If you want to run the scripts against a real database, create a
+  `.env` file from `.env.example` and supply your connection details.


### PR DESCRIPTION
## Summary
- clarify that tests run without a Neo4j instance
- explain how to configure a `.env` file when running scripts against a database

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aa46d17e48332a7d721c9b43d9a63