### PR TITLE
Add Louvain community detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Where:
 This script creates a vector index on the `Method.embedding` property if
 one does not already exist and then writes `SIMILAR` relationships with a
 `score` property for pairs of methods that exceed the similarity cutoff.
+After the similarity step it also runs the Louvain algorithm on the
+`SIMILAR` graph. Only relationships whose `score` is above
+`--community-threshold` are included in the projection. The resulting
+community id is stored on each `Method` node using the property specified
+by `--community-property` (default: `similarityCommunity`). Pass
+`--no-knn` if you want to skip the kNN step and only compute communities.
 
 ## Graph Schema
 
@@ -121,7 +127,7 @@ The scripts create the following node types and relationships:
 - `File`: Represents Java source files  
   - Properties: `path` (string), `embedding` (vector), `embedding_type` (string)
 - `Method`: Represents Java methods
-  - Properties: `name` (string), `file` (string), `line` (integer), `class` (string, optional), `embedding` (vector), `embedding_type` (string)
+  - Properties: `name` (string), `file` (string), `line` (integer), `class` (string, optional), `embedding` (vector), `embedding_type` (string), `similarityCommunity` (integer)
 
 **Relationships:**
 - `CONTAINS`: Directory contains subdirectories or files
@@ -156,6 +162,12 @@ LIMIT 10;
 MATCH (m1:Method)-[s:SIMILAR]->(m2:Method)
 RETURN m1.name, m1.class, m2.name, m2.class, s.score
 ORDER BY s.score DESC
+LIMIT 10;
+
+// Inspect the largest similarity communities
+MATCH (m:Method)
+RETURN m.similarityCommunity AS community, count(*) AS size
+ORDER BY size DESC
 LIMIT 10;
 
 // Follow a chain of method calls

--- a/tests/test_louvain.py
+++ b/tests/test_louvain.py
@@ -1,0 +1,50 @@
+import sys
+import types
+from unittest.mock import MagicMock, ANY
+import pandas as pd
+
+# Stub heavy modules before importing the code under test
+sys.modules.setdefault("graphdatascience", types.ModuleType("graphdatascience"))
+sys.modules["graphdatascience"].GraphDataScience = object
+sys.modules.setdefault("dotenv", types.ModuleType("dotenv"))
+sys.modules["dotenv"].load_dotenv = lambda override=True: None
+
+from create_method_similarity import run_louvain
+
+
+def test_run_louvain_creates_projection_and_runs():
+    gds = MagicMock()
+    gds.graph.exists.return_value = pd.Series({"exists": True})
+    graph_obj = MagicMock()
+    gds.graph.project.cypher.return_value = (graph_obj, None)
+
+    run_louvain(gds, threshold=0.9, community_property="simComm")
+
+    gds.graph.exists.assert_called_once_with("similarityGraph")
+    gds.graph.drop.assert_called_once_with("similarityGraph")
+    gds.graph.project.cypher.assert_called_once_with(
+        "similarityGraph",
+        "MATCH (m:Method) RETURN id(m) AS id",
+        ANY,
+        {
+            "relationshipProperties": "score",
+            "parameters": {"threshold": 0.9},
+            "relationshipOrientation": "UNDIRECTED",
+        },
+    )
+    gds.louvain.write.assert_called_once_with(graph_obj, writeProperty="simComm")
+    graph_obj.drop.assert_called_once()
+
+
+def test_run_louvain_without_existing_projection():
+    gds = MagicMock()
+    gds.graph.exists.return_value = pd.Series({"exists": False})
+    graph_obj = MagicMock()
+    gds.graph.project.cypher.return_value = (graph_obj, None)
+
+    run_louvain(gds)
+
+    gds.graph.drop.assert_not_called()
+    gds.graph.project.cypher.assert_called_once()
+    gds.louvain.write.assert_called_once()
+    graph_obj.drop.assert_called_once()


### PR DESCRIPTION
## Summary
- compute Louvain communities on SIMILAR relationships
- expose new CLI options in `create_method_similarity.py`
- document Louvain usage and new property in the README
- add tests for the Louvain helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7947a6548332b07d8440ced15a20