### PR TITLE
Add git history test and loader

### DIFF
--- a/git_history.py
+++ b/git_history.py
@@ -1,0 +1,83 @@
+import sys
+import argparse
+import logging
+from git import Repo
+from neo4j import GraphDatabase
+from utils import ensure_port, get_neo4j_config
+
+NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE = get_neo4j_config()
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Load git history into Neo4j")
+    parser.add_argument("repo", help="Path to the Git repository")
+    parser.add_argument("--uri", default=NEO4J_URI, help="Neo4j URI")
+    parser.add_argument("--username", default=NEO4J_USERNAME, help="Neo4j username")
+    parser.add_argument("--password", default=NEO4J_PASSWORD, help="Neo4j password")
+    parser.add_argument("--database", default=NEO4J_DATABASE, help="Neo4j database")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument("--log-file", help="Optional log file")
+    return parser.parse_args()
+
+
+def load_history(repo_path, driver, database=None):
+    repo = Repo(repo_path)
+    with driver.session(database=database) as session:
+        for commit in repo.iter_commits():
+            author = getattr(commit, "author", None)
+            email = getattr(author, "email", None)
+            name = getattr(author, "name", None)
+            session.run(
+                "MERGE (d:Developer {email:$email}) SET d.name=$name",
+                email=email,
+                name=name,
+            )
+            session.run(
+                "MERGE (c:Commit {sha:$sha}) SET c.message=$msg",
+                sha=commit.hexsha,
+                msg=getattr(commit, "message", ""),
+            )
+            session.run(
+                "MATCH (d:Developer {email:$email}), (c:Commit {sha:$sha}) "
+                "MERGE (d)-[:AUTHORED]->(c)",
+                email=email,
+                sha=commit.hexsha,
+            )
+            for path in getattr(commit, "files", []):
+                session.run(
+                    "MERGE (fv:FileVer {path:$path, sha:$sha})",
+                    path=path,
+                    sha=commit.hexsha,
+                )
+                session.run(
+                    "MATCH (c:Commit {sha:$sha}), (fv:FileVer {path:$path, sha:$sha}) "
+                    "MERGE (c)-[:CHANGED]->(fv)",
+                    sha=commit.hexsha,
+                    path=path,
+                )
+
+
+def main():
+    args = parse_args()
+    handlers = [logging.StreamHandler(sys.stdout)]
+    if args.log_file:
+        handlers.append(logging.FileHandler(args.log_file))
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), "INFO"),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+    )
+    driver = GraphDatabase.driver(
+        ensure_port(args.uri), auth=(args.username, args.password)
+    )
+    driver.verify_connectivity()
+    try:
+        load_history(args.repo, driver, args.database)
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_git_history.py
+++ b/tests/test_git_history.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Stub heavy modules
+sys.modules.setdefault("git", types.SimpleNamespace(Repo=MagicMock()))
+sys.modules.setdefault("neo4j", types.SimpleNamespace(GraphDatabase=MagicMock()))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda **k: None))
+
+import git_history
+
+
+def _make_commit(sha, name, email, files):
+    return types.SimpleNamespace(
+        hexsha=sha,
+        message=f"msg {sha}",
+        author=types.SimpleNamespace(name=name, email=email),
+        files=files,
+    )
+
+
+def test_load_history_runs_expected_queries():
+    repo_mock = MagicMock()
+    repo_mock.iter_commits.return_value = [
+        _make_commit("a1", "Alice", "a@example.com", ["foo.java"]),
+        _make_commit("b2", "Bob", "b@example.com", ["foo.java", "bar.java"]),
+    ]
+    git_history.Repo.return_value = repo_mock
+
+    session_mock = MagicMock()
+    session_cm = MagicMock()
+    session_cm.__enter__.return_value = session_mock
+    driver_mock = MagicMock()
+    driver_mock.session.return_value = session_cm
+
+    git_history.load_history("repo", driver_mock)
+
+    queries = [c.args[0] for c in session_mock.run.call_args_list]
+    assert any("Developer" in q for q in queries)
+    assert any("Commit" in q for q in queries)
+    assert any("FileVer" in q for q in queries)
+    assert any("AUTHORED" in q for q in queries)
+    assert any("CHANGED" in q for q in queries)


### PR DESCRIPTION
## Summary
- implement a minimal `git_history.py` module for loading commit data into Neo4j
- add a test `tests/test_git_history.py` that stubs heavy dependencies and verifies the queries

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7e898dc08332b0ae29b894e0c947