### PR TITLE
Ensure GDS connection cleanup

### DIFF
--- a/src/analysis/centrality.py
+++ b/src/analysis/centrality.py
@@ -392,6 +392,7 @@ def main():
 
     setup_logging(args.log_level, args.log_file)
     driver = create_neo4j_driver(args.uri, args.username, args.password)
+    gds = None
 
     try:
         # Initialize GDS
@@ -455,6 +456,11 @@ def main():
         logger.error(f"Analysis failed: {e}")
         raise
     finally:
+        if gds is not None:
+            try:
+                gds.close()
+            except Exception:
+                logger.warning("Failed to close GraphDataScience connection")
         driver.close()
 
 


### PR DESCRIPTION
## Summary
- initialize `gds` before connecting in `centrality.py`
- close the `GraphDataScience` connection in `finally`

## Testing
- `flake8 src/ tests/ --max-line-length=100` *(fails: E501 line too long)*
- `mypy src/ --ignore-missing-imports`
- `pytest tests/ -v` *(fails: 4 failed, 52 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68884882f37c8332b05992f7d00c4a82