### PR TITLE
Update logging setup to force configuration

### DIFF
--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -36,6 +36,7 @@ def setup_logging(log_level: Union[str, int] = "INFO", log_file: Optional[str] =
         level=level,
         format="%(asctime)s [%(levelname)s] %(message)s",
         handlers=handlers,
+        force=True,
     )
 
 


### PR DESCRIPTION
## Summary
- ensure `logging.basicConfig` forces reconfiguration

## Testing
- `isort src/ tests/ scripts/`
- `black src/ tests/ scripts/`
- `isort --check-only --diff src/ tests/ scripts/`
- `black --check --diff src/ tests/ scripts/`
- `flake8 src/ tests/ --max-line-length=100` *(fails: E501 line too long)*
- `mypy src/ --ignore-missing-imports`
- `pytest tests/ -v` *(fails: connection refused and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6888494d8f7483328c33c0b3758bf057