### PR TITLE
Ensure dotenv is loaded for NVD key check

### DIFF
--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -317,7 +317,10 @@ class PipelineManager:
         """Check if NVD API key is available."""
         import os
 
-        return bool(os.getenv("NVD_API_KEY") or Path(".env").exists())
+        from dotenv import load_dotenv
+
+        load_dotenv(override=True)
+        return bool(os.getenv("NVD_API_KEY"))
 
     def _retry_step(self, step: PipelineStep) -> bool:
         """Retry a failed step."""

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Ensure src is on the Python path before importing PipelineManager
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+sys.modules.setdefault("dotenv", SimpleNamespace(load_dotenv=lambda **k: None))
+
+from src.pipeline.manager import PipelineManager
+
+
+def test_has_nvd_api_key(monkeypatch):
+    monkeypatch.setattr("dotenv.load_dotenv", lambda override=True: None)
+    monkeypatch.delenv("NVD_API_KEY", raising=False)
+
+    manager = PipelineManager("https://example.com/repo.git")
+
+    assert manager._has_nvd_api_key() is False
+
+    monkeypatch.setenv("NVD_API_KEY", "secret")
+    assert manager._has_nvd_api_key() is True


### PR DESCRIPTION
## Summary
- load `.env` with override in `_has_nvd_api_key`
- add test verifying function behaviour

## Testing
- `isort src/ tests/ scripts/`
- `black src/ tests/ scripts/`
- `isort --check-only --diff src/ tests/ scripts/`
- `black --check --diff src/ tests/ scripts/`
- `flake8 src/ tests/ --max-line-length=100` *(fails: E501 line too long)*
- `mypy src/ --ignore-missing-imports`
- `pytest tests/test_pipeline_manager.py -v`
- `pytest tests/ -v` *(fails: 4 failed, 53 passed, 1 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_688849a8a3588332b96e6a47e091943c