### PR TITLE
Improve Gradle dependency regex

### DIFF
--- a/src/analysis/code_analysis.py
+++ b/src/analysis/code_analysis.py
@@ -142,18 +142,26 @@ def _extract_gradle_dependencies(gradle_file):
         with open(gradle_file, "r", encoding="utf-8") as f:
             content = f.read()
 
-        # Pattern for Gradle dependencies like: implementation 'group:artifact:version'
+        # Regex patterns capturing groupId, artifactId and version
         patterns = [
-            r"['\"]([a-zA-Z][a-zA-Z0-9_.\\-]+):([a-zA-Z][a-zA-Z0-9_.\\-]+):([^'\"\\s]+)['\"]",
-            r"group\s*:\s*['\"]([^'\"]+)['\"].*?name\s*:\s*['\"]([^'\"]+)['\"]"
-            r".*?version\s*:\s*['\"]([^'\"]+)['\"]",
-            r"group\s*=\s*['\"]([^'\"]+)['\"].*?name\s*=\s*['\"]([^'\"]+)['\"]"
-            r".*?version\s*=\s*['\"]([^'\"]+)['\"]",
+            # implementation 'group:artifact:version'
+            (
+                r"(?:implementation|api|compile|testImplementation|testCompile|runtime)\s+[\"']"
+                r"([a-zA-Z0-9._-]+):([a-zA-Z0-9._-]+):([^\"'\s]+)[\"']"
+            ),
+            # implementation group: 'group', name: 'artifact', version: '1.0.0'
+            (
+                r"(?:implementation|api|compile|testImplementation|testCompile|runtime)\s+.*?"
+                r"group\s*[:=]\s*[\"']([a-zA-Z0-9._-]+)[\"'].*?"
+                r"name\s*[:=]\s*[\"']([a-zA-Z0-9._-]+)[\"'].*?"
+                r"version\s*[:=]\s*[\"']([^\"']+)[\"']"
+            ),
         ]
-
         for pattern in patterns:
             matches = re.finditer(pattern, content, re.MULTILINE | re.DOTALL)
             for match in matches:
+                if len(match.groups()) != 3 or None in match.groups():
+                    continue
                 group_id, artifact_id, version = match.groups()
                 package_name = f"{group_id}.{artifact_id}"
 

--- a/src/security/gav_cve_matcher.py
+++ b/src/security/gav_cve_matcher.py
@@ -36,6 +36,14 @@ class GAVCoordinate:
         """Return package key for matching (group:artifact)."""
         return f"{self.group_id}:{self.artifact_id}"
 
+    def is_in_range(self, start_version: str, end_version: str) -> bool:
+        """Check if this coordinate's version falls within [start, end)."""
+        try:
+            current = Version(self.version)
+            return Version(start_version) <= current < Version(end_version)
+        except Exception:
+            return False
+
 
 @dataclass
 class CVEVulnerability:

--- a/tests/test_gradle_extraction.py
+++ b/tests/test_gradle_extraction.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from src.analysis.code_analysis import _extract_gradle_dependencies
+
+
+def test_standard_dependency(tmp_path):
+    gradle_file = tmp_path / "build.gradle"
+    gradle_file.write_text("dependencies { implementation 'org.example:lib:1.2.3' }")
+
+    deps = _extract_gradle_dependencies(gradle_file)
+    assert deps["org.example.lib"] == "1.2.3"
+    assert deps["org.example"] == "1.2.3"
+
+
+def test_map_style_dependency(tmp_path):
+    gradle_file = tmp_path / "build.gradle"
+    gradle_file.write_text(
+        "dependencies { implementation group: 'junit', name: 'junit', version: '4.13.2' }"
+    )
+
+    deps = _extract_gradle_dependencies(gradle_file)
+    assert deps["junit.junit"] == "4.13.2"
+    assert deps["junit"] == "4.13.2"


### PR DESCRIPTION
## Summary
- parse Gradle dependencies using single regexes that capture group, artifact and version
- ensure matches are unpacked only when all three groups exist
- implement `is_in_range` helper on `GAVCoordinate`
- test Gradle dependency extraction patterns

## Testing
- `pre-commit run --all-files`
- `mypy src/ --ignore-missing-imports`
- `pytest tests/test_gradle_extraction.py -v`
- `pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'graphdatascience', AttributeError: 'GAVCoordinate' object has no attribute 'is_in_range', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688849ae65948332bb873ec65e62eca9